### PR TITLE
issue #4 - markdown tweaks for html

### DIFF
--- a/adventure/output.py
+++ b/adventure/output.py
@@ -3,9 +3,9 @@ import re
 
 class MarkdownRE:
     def __init__(self):
-        self.re_emphasis = re.compile(r'(\*)([^*]+)\1')
-        self.re_strong = re.compile(r'(\*{2})(.+?)\1')
-        self.re_underline = re.compile(r'(_{2})(.+?)\1')
+        self.re_emphasis = re.compile(r"(\*)([^*]+)\1")
+        self.re_strong = re.compile(r"(\*{2})(.+?)\1")
+        self.re_underline = re.compile(r"(_{2})(.+?)\1")
 
 
 class MarkdownToRich(MarkdownRE):
@@ -13,15 +13,21 @@ class MarkdownToRich(MarkdownRE):
         super().__init__()
 
     def transform(self, text):
-        text = self.re_strong.sub(r'[yellow]\2[/yellow]', text)
-        text = self.re_underline.sub(r'[underline]\2[/underline]', text)
+        text = self.re_strong.sub(r"[yellow]\2[/yellow]", text)
+        text = self.re_underline.sub(r"[underline]\2[/underline]", text)
         return text
 
 
 class MarkdownPassthru:
-    """Markdown raw passthru"""
+    """Markdown [mostly] raw passthru"""
+
     def transform(self, text: str) -> str:
-        return text
+        new_lines = []
+        for line in text.split("\n"):
+            new_lines.append(
+                line.strip()
+            )  # md freaks out about leading/trailing spaces!
+        return "\n".join(new_lines)
 
 
 class MarkdownToHTML(MarkdownRE):
@@ -29,6 +35,6 @@ class MarkdownToHTML(MarkdownRE):
         super().__init__()
 
     def transform(self, text):
-        text = self.re_strong.sub(r'<b>\2</b>', text)
-        text = self.re_underline.sub(r'<u>\2</u>', text)
+        text = self.re_strong.sub(r"<b>\2</b>", text)
+        text = self.re_underline.sub(r"<u>\2</u>", text)
         return text

--- a/adventure/westofhouse.py
+++ b/adventure/westofhouse.py
@@ -7,71 +7,86 @@ from .util import get_cwd
 
 class Leaflet(Item):
     def __init__(self):
-        with open(os.path.join(get_cwd(), 'data', 'leaflet.txt')) as f:
+        with open(os.path.join(get_cwd(), "data", "leaflet.txt")) as f:
             txt = f.read()
-            txt = txt.replace(r'\t', r'    ')
-        super().__init__(name='leaflet', full_name='a small leaflet', contents=txt.rstrip(),
-                         needs_held_to_be_examined=True, can_be_taken=True)
+            txt = txt.replace(r"\t", r"    ")
+        super().__init__(
+            name="leaflet",
+            full_name="a small leaflet",
+            contents=txt.rstrip(),
+            needs_held_to_be_examined=True,
+            can_be_taken=True,
+        )
 
     def examine(self):
-        markdown = self.features['contents']
+        markdown = self.features["contents"]
         return markdown
 
 
 class Mailbox(Item, StateMachine):
     def __init__(self):
-        Item.__init__(self, 'mailbox', full_name='a small mailbox', contains=[Leaflet()])
-        StateMachine.__init__(self, states={'opened': self.open, 'closed': self.close}, initial='closed')
+        Item.__init__(
+            self, "mailbox", full_name="a small mailbox", contains=[Leaflet()]
+        )
+        StateMachine.__init__(
+            self, states={"opened": self.open, "closed": self.close}, initial="closed"
+        )
 
     def list_items(self):
-        txt = ''
-        items = self.features['contains'] if self.current_state == 'opened' else []
+        txt = ""
+        items = self.features["contains"] if self.current_state == "opened" else []
         length = len(items)
-        indent = '- '
+        indent = "    "  # 4 space indent
         if length > 0:
-            txt += '\nThe mailbox contains:\n'
+            txt += "\nThe mailbox contains:\n"
             if length == 1:
-                txt += indent + items[0].full_name.capitalize() + '.'
+                txt += indent + items[0].full_name.capitalize() + "."
             elif length == 2:
-                txt += indent + items[0].full_name.capitalize() + ' and ' + items[1].full_name + ' here.'
+                txt += (
+                    indent
+                    + items[0].full_name.capitalize()
+                    + " and "
+                    + items[1].full_name
+                    + " here."
+                )
             else:
                 txt += indent
-                for i in range(length-3):
-                    txt += items[i].full_name.capitalize() + ', '
-                for i in range(length-2):
-                    txt += items[i].full_name + ' and '
-                txt += items[length-1].full_name + ' here.'
+                for i in range(length - 3):
+                    txt += items[i].full_name.capitalize() + ", "
+                for i in range(length - 2):
+                    txt += items[i].full_name + " and "
+                txt += items[length - 1].full_name + " here."
         return txt
 
     def open(self):
-        if self.current_state == 'closed':
-            self.switch_state('opened')
-            if self.features.get('contains'):
-                txt = 'You open the mailbox, revealing a small leaflet.'
+        if self.current_state == "closed":
+            self.switch_state("opened")
+            if self.features.get("contains"):
+                txt = "You open the mailbox, revealing a small leaflet."
             else:
-                txt = 'You open the mailbox.'
+                txt = "You open the mailbox."
         else:
-            txt = 'The mailbox is already open.'
+            txt = "The mailbox is already open."
         return txt
 
     def close(self):
-        if self.current_state == 'opened':
-            self.switch_state('closed')
-            txt = 'You close the mailbox.'
+        if self.current_state == "opened":
+            self.switch_state("closed")
+            txt = "You close the mailbox."
         else:
             txt = "That's already closed."
         return txt
 
     def take(self):
-        return 'What a concept!'
+        return "What a concept!"
 
 
 class BoardedDoor(Item):
     def __init__(self):
-        super().__init__(name='door', hidden=True)
+        super().__init__(name="door", hidden=True)
 
     def open(self):
-        return 'The door cannot be opened.'
+        return "The door cannot be opened."
 
     def close(self):
         return "That's not something you can close."
@@ -79,11 +94,15 @@ class BoardedDoor(Item):
 
 class WelcomeMat(Item):
     def __init__(self):
-        super().__init__(name='mat', full_name='a welcome mat',
-                         description="A rubber mat saying 'Welcome to Zork!' lies by the door.", can_be_taken=True)
+        super().__init__(
+            name="mat",
+            full_name="a welcome mat",
+            description="A rubber mat saying 'Welcome to Zork!' lies by the door.",
+            can_be_taken=True,
+        )
 
     def examine(self):
-        return 'Welcome to Zork!'
+        return "Welcome to Zork!"
 
     def open(self):
         return "That's not something you can open."
@@ -98,5 +117,5 @@ class WelcomeMat(Item):
 class WestOfHouse(Location):
     def __init__(self):
         items = [Mailbox(), BoardedDoor(), WelcomeMat()]
-        can_go = {'north': 'NorthOfHouse'}
-        super().__init__(title='West of House', contains=items, accessible=can_go)
+        can_go = {"north": "NorthOfHouse"}
+        super().__init__(title="West of House", contains=items, accessible=can_go)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -87,7 +87,7 @@ def test_open_mailbox_and_look():
 This is an open field west of a white house, with a boarded front door.
 There is a small mailbox here.
 The mailbox contains:
-- A small leaflet.
+    A small leaflet.
 A rubber mat saying 'Welcome to Zork!' lies by the door.""")
 
 

--- a/web/app.py
+++ b/web/app.py
@@ -1,7 +1,6 @@
 import base64
 
 import hug
-import markdown
 
 from adventure.app import Adventure
 from adventure.output import MarkdownPassthru
@@ -10,7 +9,7 @@ from .models import init_db
 from .session_store import AdventureSessionStore
 from .settings import settings
 from .template_loader import get_template
-
+from .utils import markdown2html
 
 html = hug.get(output=hug.output_format.html)
 api = hug.API(__name__)
@@ -31,12 +30,13 @@ def health_check():
 @html.urls("/")
 def index(session: hug.directives.session):
     """main index / page"""
-    starting_text = "resuming..."
+    starting_text = ""
     if not session:
-        starting_text = markdown.markdown(
+        starting_text = markdown2html(
             Adventure(output_strategy=MarkdownPassthru()).current_room.description
         )
-    # TODO: actually set the session_id if there is one
+    else:
+        starting_text = f"Resuming (session: {session.get('session_id')})"
     return get_template("index.html").render(session_id="", starting_text=starting_text)
 
 
@@ -46,7 +46,7 @@ def adventure_api(session: hug.directives.session, input_data: str):
     adventure = Adventure(output_strategy=MarkdownPassthru())
     if session and session.get("save_data"):
         adventure.admin_load(base64.b64decode(session["save_data"].encode()))
-    _output = markdown.markdown(adventure.execute(input_data.split()))
+    _output = markdown2html(adventure.execute(input_data.split()))
     session["save_data"] = base64.b64encode(adventure.admin_save()).decode("ascii")
     return {"input": input_data, "output": _output}
 

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -23,9 +23,6 @@
         <article>
             <h1>Zork Demo</h1>
             <p class="subtitle">A Python demo rewrite of Zork</p>
-            <section>
-                <p>Session ID: {{ session_id }}</p>
-            </section>
             <section id="output-content">
                 <p class="output">{{ starting_text|safe }}</p>
             </section>

--- a/web/tests/test_endpoints.py
+++ b/web/tests/test_endpoints.py
@@ -49,11 +49,12 @@ def test_api():
         assert result.status == hug.status.HTTP_200
         assert result.data == {
             "input": "dance",
-            "output": "<p>I really don't know how to dance.</p>",
+            "output": "<p>I really don&rsquo;t know how to dance.</p>",  # smarty quotes
         }
         result = hug.test.post(api, url="/api", params={"input_data": "look"})
         assert result.status == hug.status.HTTP_200
+        # tests for <br /> on \n now
         assert result.data == {
             "input": "look",
-            "output": "<p><strong>Snowy Woods</strong>\n Whose woods these are I <em>think</em> I know.</p>",
+            "output": "<p><strong>Snowy Woods</strong><br />\n Whose woods these are I <em>think</em> I know.</p>",
         }

--- a/web/utils.py
+++ b/web/utils.py
@@ -1,0 +1,13 @@
+import markdown
+
+
+MARKDOWN_EXTENSIONS = [
+    "nl2br",  # turn all single \n into <br/>
+    "sane_lists",  # in case we ever do lists
+    "smarty",  # fancier quotes and things
+]
+
+
+def markdown2html(text: str) -> str:
+    """Do all our markdown -> html in one place"""
+    return markdown.markdown(text, extensions=MARKDOWN_EXTENSIONS)


### PR DESCRIPTION
Apologies for `black` making part of the PR a bit bigger.

Utilized some available markdown plugins to make the md -> html go more like you wanted.

Biggest change is treating `\n` as significant. Also added `smarty` for doing nicer quoting (close and end quotes) so the output looks a little nicer. Did some minor cleanup around the actual HTML itself. I'll attach screenshots showing web vs console.